### PR TITLE
fix(ui): patched the invisible left border of the codeblock in builder page. 

### DIFF
--- a/app/_components/component-code.tsx
+++ b/app/_components/component-code.tsx
@@ -429,7 +429,7 @@ export function CodeComponent() {
               className="flex flex-col md:flex-row relative w-full gap-2 min-h-full"
               key={framework}
             >
-              <div className="sticky w-full p-2 sm:w-full md:w-80 -z-20 dark:backdrop-blur-2xl top-0 left-0">
+              <div className="sticky w-full p-2 sm:w-full md:w-80 z-20 dark:backdrop-blur-2xl top-0 left-1">
                 <div className="flex relative justify-between h-full flex-col">
                   <FileTree
                     currentSlug={currentSlug}


### PR DESCRIPTION
added padding on the fileTree to make the left border to be visible.
