### PR TITLE
fix: Update Logo component to use camelCase SVG props (fillRule, clipRule)

### DIFF
--- a/components/logo.tsx
+++ b/components/logo.tsx
@@ -12,8 +12,8 @@ export const Logo = (props: SVGProps<any>) => {
       {...props}
     >
       <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
+        fillRule="evenodd" // Changed from fill-rule
+        clipRule="evenodd" // Changed from clip-rule
         d="M0 0H15V15H30V30H15V45H0V30V15V0ZM45 30V15H30V0H45H60V15V30V45H45H30V30H45Z"
         className="fill-black dark:fill-white"
       />


### PR DESCRIPTION
This PR updates components/logo.tsx to use fillRule="evenodd" and clipRule="evenodd" instead of fill-rule and clip-rule to resolve React JSX warnings during Next.js SSR. The change preserves Tailwind styling (fill-black dark:fill-white) and ensures compatibility.

Testing: Ran npm run dev no warnings, Logo renders correctly in login components.
Notes: Includes recent commits; let me know if splitting is needed!

